### PR TITLE
fixed small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ in which I've added the missing "swingModes" array, supported by climate but not
 
 `<DEVICE_TYPE>`, `<IP>`, `<MAC_ADDR>` parameter can be obtained running:
 ```bash
-$ broadlink-listener discover_ir
+$ broadlink-listener discover-ir
 ```
 
 


### PR DESCRIPTION
$ broadlink-listener discover_ir
Usage: broadlink-listener [OPTIONS] COMMAND [ARGS]...
Try 'broadlink-listener --help' for help.

Error: No such command 'discover_ir'. Did you mean 'discover-ir'?

$ broadlink-listener discover-ir
Broadlink listener - v1.2.0

not a big PR but I thought it helps :) 